### PR TITLE
[DATA-468] Add data access synchronization to camera servers

### DIFF
--- a/intelrealserver.cpp
+++ b/intelrealserver.cpp
@@ -30,7 +30,7 @@ void cameraThread() {
         pipe.start(cfg);
         pipelines.push_back(pipe);
 
-        CameraState::get()->cameras.push_back(0);
+        CameraState::get()->addCamera();
     }
 
     if (pipelines.size() == 0) {
@@ -86,20 +86,21 @@ void cameraThread() {
                               depth.get_width(), depth.get_height(),
                               (const char*)depth.get_data());
 
-	    int w = output->depth_width;
-	    int h = output->depth_height;
-	    cv::Mat cvBuf(h, w, CV_16U);
-	    const uint16_t *z_pixels = reinterpret_cast<const uint16_t*>(depth.get_data());
-	    for (int y = 0; y < h; y++) {
-	      for (int x = 0; x < w; x++) { 
-		cvBuf.at<uint16_t>(y,x) = z_pixels[y*w+x];
-	      }
-	    }
-	    output->depth_cv = cvBuf;
+            int w = output->depth_width;
+            int h = output->depth_height;
+            cv::Mat cvBuf(h, w, CV_16U);
+            const uint16_t* z_pixels =
+                reinterpret_cast<const uint16_t*>(depth.get_data());
+            for (int y = 0; y < h; y++) {
+                for (int x = 0; x < w; x++) {
+                    cvBuf.at<uint16_t>(y, x) = z_pixels[y * w + x];
+                }
+            }
+            output->depth_cv = cvBuf;
             DEBUG("middle distance: " << depth.get_distance(
                       depth.get_width() / 2, depth.get_height() / 2));
 
-            CameraState::get()->cameras[num++] = output;
+            CameraState::get()->setCameraOutput(num++, output);
         }
 
         auto finish = std::chrono::high_resolution_clock::now();
@@ -110,7 +111,7 @@ void cameraThread() {
 
         CameraState::get()->ready = 1;
 
-        if (time(0) - CameraState::get()->lastRequest > 30) {
+        if (time(0) - CameraState::get()->getLastRequest() > 30) {
             DEBUG("sleeping");
             sleep(1);
         }

--- a/opencvserver.cpp
+++ b/opencvserver.cpp
@@ -87,11 +87,11 @@ void cameraThread() {
         output->ppmdata = my_write_ppm((const char*)frame.data, output->width,
                                        output->height, 3);
 
-        CameraState::get()->cameras[0] = output;
+        CameraState::get()->setCameraOutput(0, output);
 
         CameraState::get()->ready = 1;
 
-        if (time(0) - CameraState::get()->lastRequest > 30) {
+        if (time(0) - CameraState::get()->getLastRequest() > 30) {
             DEBUG("sleeping");
             sleep(1);
         }
@@ -100,7 +100,7 @@ void cameraThread() {
 
 int main(int argc, char** argv) {
     TheCamera = findCamera();
-    CameraState::get()->cameras.push_back(0);
+    CameraState::get()->addCamera();
 
     int port = 8182;
 

--- a/royaleserver.cpp
+++ b/royaleserver.cpp
@@ -43,7 +43,7 @@ class MyListener : public IDepthDataListener {
         {
             std::stringbuf buffer;
             std::ostream os(&buffer);
-	        cv::Mat cvBuf(output->depth_height, output->depth_width, CV_16U);
+            cv::Mat cvBuf(output->depth_height, output->depth_width, CV_16U);
 
             os << "VERSIONX\n";
             os << "2\n";
@@ -64,7 +64,7 @@ class MyListener : public IDepthDataListener {
                     short s = short(1000 * val.z);
 
                     buffer.sputn((const char*)&s, 2);
-		            cvBuf.at<short>(y, x) = s;
+                    cvBuf.at<short>(y, x) = s;
                 }
             }
             output->depth = buffer.str();
@@ -99,7 +99,7 @@ class MyListener : public IDepthDataListener {
             output->ppmdata = buffer.str();
         }
 
-        CameraState::get()->cameras[0] = output;
+        CameraState::get()->setCameraOutput(0, output);
 
         CameraState::get()->ready = 1;
     }
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
     }
 
     // signal we have one and only 1 camera
-    CameraState::get()->cameras.push_back(0);
+    CameraState::get()->addCamera();
 
     auto status = cameraDevice->initialize();
     if (status != CameraStatus::SUCCESS) {


### PR DESCRIPTION
This fixes race conditions accessing the members of `CameraState`. So far I've viewing camera output in rdk, and it looks good. I also want to try running the images through slam, but I'm running into an unrelated error.

I apologize, some of the changes are due to make format. Maybe I'll add a github action to check make format for this repo, now that I have a little experience with github actions :)

**UPDATE** slam tests look good