### PR TITLE
RAW color and depth endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,5 +94,3 @@ appimages: clean default
 
 appimages-deploy:
 	gsutil -m -h "Cache-Control: no-cache" cp packaging/appimages/deploy/* gs://packages.viam.com/apps/camera-servers/
-
-include *.make

--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,5 @@ appimages: clean default
 
 appimages-deploy:
 	gsutil -m -h "Cache-Control: no-cache" cp packaging/appimages/deploy/* gs://packages.viam.com/apps/camera-servers/
+
+include *.make

--- a/README.md
+++ b/README.md
@@ -79,7 +79,87 @@ You can then export an AppImage of the binary using
 ```
 cd packaging/appimages && appimage-builder --recipe intelrealgrpcserver-`uname -m`.yml
 ```
-## Query a VIAM gRPC camera server
+
+## Adding a gRPC camera as a remote to your robot
+
+### Start the server on robot start up
+
+On app.viam.com, go to Config -> Processes, and put in the following:
+
+**Executable**: /usr/local/bin/intelrealgrpcserver
+**Working Directory**: Leave it blank
+**Arguments**: All arguments are optional, and positional
+
+* 1st argument: port number, `int` (default is 8085)
+* 2nd: color width, `int`
+* 3rd: color height, `int`
+* 4th: depth width, `int`
+* 5th: depth height, `int`
+
+If you just want the defaults, leave “args” field blank. If you dont put in anything, this will set up the gRPC server running on port 8085 of your pi with the default resolution.
+
+The JSON of the process will look like the following:
+```
+[ 
+  { 
+    "id": "intel", 
+    "log": true, 
+    "name": "/usr/local/bin/intelrealgrpcserver",
+    "args": [port_number, color_width, color_height, depth_width, depth_height] // Put the actual numbers you want here. If the realsense does not support the requested height and width it will error and fail to start
+ 
+  } 
+]
+```
+Additionally, after `depth_height` you can use `--disable-depth` `--disable-color` to disable streaming of depth or color.
+
+### Add the gRPC server as a remote
+
+Then go to Config -> Remotes, and add the following 
+
+**Address**: 127.0.0.1:8085 // if you changed the port number in the arguments, it won't be 8085.
+**TLS**: Off
+
+The JSON of the process will look like the following:
+```
+[
+ {
+   "name": "intel",
+   "address": "127.0.0.1:8085",
+   "insecure": true
+ }
+]
+```
+
+This will add the two cameras to your robot. They will have the names `intel:color` and `intel:depth`.
+
+### Create camera to display point clouds
+
+Go to Config -> Components, and add the following camera model, `align_color_depth`. 
+```
+ {
+        "output_image_type": "color",
+    // you can get intrinsics by calling GetProperties on the intel gRPC camera server, too
+        "intrinsic_parameters": {  // intrinsic parameters depend on the resolution of the camera
+            "height_px": 720,
+            "width_px": 1280,
+            "ppx": 648.1280,
+            "ppy": 367.736,
+            "fx": 900.538,
+            "fy": 900.818
+        },
+        "color_camera_name": "intel:color",
+        "depth_camera_name": "intel:depth"
+      }
+}
+"depends_on": [
+   "intel:color",
+   "intel:depth"
+]
+```
+ 
+Now in the *Control tab*, you can see both the individual 2D camera streams, as well as the pointcloud camera of the combined color and depth image that you created with `align_color_depth`.
+
+## Query a VIAM gRPC camera server with grpcURL
 
 If you have a gRPC camera server running and would like to directly query the camera, here are the instructions of how to do so.
 
@@ -87,7 +167,7 @@ Make sure you have `buf` installed.
 
 ### Know what address and port the server is running on
 
-e.g. `my-server-url.local:8085`
+e.g. `127.0.0.1:8085`
 
 and make sure the server is running
 
@@ -116,13 +196,13 @@ The available VIAM camera methods are
 From within the API directory, you can run commands like
 
 ```
-$ grpcurl -plaintext -protoset <(buf build -o - buf.build/viamrobotics/api) my-server-url.local:8085 viam.robot.v1.RobotService/ResourceNames
+$ grpcurl -plaintext -protoset <(buf build -o - buf.build/viamrobotics/api) 127.0.0.1:8085 viam.robot.v1.RobotService/ResourceNames
 
 
-$ grpcurl -plaintext -d '{ "name": "color" }' -protoset <(buf build -o - buf.build/viamrobotics/api) my-server-url.local:8085 viam.component.camera.v1.CameraService/GetProperties
+$ grpcurl -plaintext -d '{ "name": "color" }' -protoset <(buf build -o - buf.build/viamrobotics/api) 127.0.0.1:8085 viam.component.camera.v1.CameraService/GetProperties
 
 
-$ grpcurl -max-msg-sz 10485760 -plaintext -d '{ "name": "color", "mimeType": "image/jpeg" }' -protoset <(buf build -o - buf.build/viamrobotics/api) my-server-url.local:8085 viam.component.camera.v1.CameraService/GetImage
+$ grpcurl -max-msg-sz 10485760 -plaintext -d '{ "name": "color", "mimeType": "image/jpeg" }' -protoset <(buf build -o - buf.build/viamrobotics/api) 127.0.0.1:8085 viam.component.camera.v1.CameraService/GetImage
 ```
 
 ### Handling the responses from the servers
@@ -134,70 +214,9 @@ You can use the program [jq](https://stedolan.github.io/jq/) to extract the rele
 ```
 $ cd api
 
-$ grpcurl -max-msg-sz 10485760 -plaintext -d '{ "name": "color", "mimeType": "image/jpeg" }' -protoset <(buf build -o - buf.build/viamrobotics/api) my-server-url.local:8085 viam.component.camera.v1.CameraService/GetImage | jq -r ".image" | base64 --decode >> output_image.jpeg
+$ grpcurl -max-msg-sz 10485760 -plaintext -d '{ "name": "color", "mimeType": "image/jpeg" }' -protoset <(buf build -o - buf.build/viamrobotics/api) 127.0.0.1:8085 viam.component.camera.v1.CameraService/GetImage | jq -r ".image" | base64 --decode >> output_image.jpeg
 
 $ open output_image.jpeg
 ```
 
-## Adding a gRPC camera as a remote to your robot
-
-### Start the server on robot start up
-
-On app.viam.com, go to Config -> Processes, and put in the following:
-```
-[ 
-  { 
-    "id": "intel", 
-    "log": true, 
-    "name": "/usr/local/bin/intelrealgrpcserver",
-    "args": [port_number, color_width, color_height, depth_width, depth_height] // Put the actual numbers you want here. If the realsense does not support the requested height and width it will error and fail to start
- 
-  } 
-]
-```
-If you just want the defaults, dont include the “args” field. If you dont put in anything, this will set up the gRPC server running on port 8085 of your pi with the default resolution.
-
-Additionally, after `depth_height` you can use `--disable-depth` `--disable-color` to disable streaming of depth or color.
-
-### Add the gRPC server as a remote
-
-Then go to Config -> Remotes, and add the following 
-```
-[
- {
-   "name": "intel",
-   "address": "ip-address-of-your-pi:8085", // or whatever port number you set
-   "insecure": true
- }
-]
-```
-
-This will add the two cameras to your robot. They will have the names `intel:color` and `intel:depth`.
-
-### Create camera to display point clouds
-
-Go to Config -> Components, and add the following camera model, `align_color_depth`. 
-```
- {
-        "output_image_type": "color",
-    // you can get intrinsics by calling GetProperties on the intel gRPC camera server, too
-        "intrinsic_parameters": { 
-            "height_px": 720,
-            "width_px": 1280,
-            "ppx": 648.1280,
-            "ppy": 367.736,
-            "fx": 900.538,
-            "fy": 900.818
-        },
-        "color_camera_name": "intel:color",
-        "depth_camera_name": "intel:depth"
-      }
-}
-"depends_on": [
-   "intel:color",
-   "intel:depth"
-]
-```
- 
-Now in the *Control tab*, you can see both the individual 2D camera streams, as well as the pointcloud camera of the combined color and depth image that you created with `align_color_depth`.
 

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -342,7 +342,7 @@ class CameraServiceImpl final : public CameraService::Service {
             }
             if (reqMimeType.compare("image/vnd.viam.dep") == 0) {
                 encodeDepthRAWToResponse(response, (const unsigned char*)latestDepthFrame->data(),
-                                         this->props.color.width, this->props.color.height);
+                                         this->props.depth.width, this->props.depth.height);
             } else {
                 encodeDepthPNGToResponse(response, (const unsigned char*)latestDepthFrame->data(),
                                          this->props.depth.width, this->props.depth.height);

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -334,7 +334,7 @@ void frameLoop(rs2::pipeline pipeline, AtomicFrameSet& frameSet, promise<void>& 
 	// scale every pixel value to be depth in units of mm
 	unique_ptr<vector<uint16_t>> depthFrameScaled;
         if (!disableDepth) {
-		auto depthFrame = frames.getDepthFrame();
+		auto depthFrame = frames.get_depth_frame();
 		auto depthWidth = depthFrame.get_width();
 		auto depthHeight = depthFrame.get_height();
 		const uint16_t* depthFrameData = (const uint16_t*)depthFrame.get_data();
@@ -377,7 +377,7 @@ float getDepthScale(rs2::device dev)
         // Check if the sensor if a depth sensor
         if (rs2::depth_sensor dpt = sensor.as<rs2::depth_sensor>())
         {
-            return dpt.getDepthScale() * 1000.0; // rs2 gives pix2meters
+            return dpt.get_depth_scale() * 1000.0; // rs2 gives pix2meters
         }
     }
     throw std::runtime_error("Device does not have a depth sensor");

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -78,6 +78,163 @@ void intToByteArray(const uint num, unsigned char* intBytes) {
     }
 }
 
+// DEPTH responses
+tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, const uint width, const uint height) {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    if (DEBUG) {
+        start = chrono::high_resolution_clock::now();
+    }
+
+    unsigned char* encoded = 0;
+    size_t encoded_size = 0;
+    unsigned result = lodepng_encode_memory(&encoded, &encoded_size, data, width, height, LCT_GREY, 16);
+    if (result != 0) {
+        cerr << "[GetImage]  failed to encode depth PNG" << endl;
+        return {encoded, encoded_size, false};
+    }
+
+    if (DEBUG) {
+        auto stop = chrono::high_resolution_clock::now();
+        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
+        cout << "[GetImage]  PNG depth encode:      " << duration.count() << "ms\n";
+    }
+
+    return {encoded, encoded_size, true};
+}
+
+grpc::Status encodeDepthPNGToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
+                                 const uint height) {
+    const auto& [encoded, encoded_size, ok] = encodeDepthPNG(data, width, height);
+    if (!ok) {
+        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode depth PNG");
+    }
+    response->set_mime_type("image/png");
+    response->set_image(encoded, encoded_size);
+    std::free(encoded);
+    return grpc::Status::OK;
+}
+
+tuple<unsigned char*, size_t, bool> encodeDepthRAW(const unsigned char* data, const uint64_t width, const uint64_t height) {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    if (DEBUG) {
+        start = chrono::high_resolution_clock::now();
+    }
+
+    // Depth header contains 8 bytes worth of magic number, followed by 8 bytes for width and another 8 bytes for height 
+    // each pixel has 2 bytes.
+    size_t pixelByteCount = 2*width*height;
+    size_t magicByteCount = sizeof(depthMagicNumber);
+    size_t widthByteCount = sizeof(width);
+    size_t heightByteCount = sizeof(height);
+    size_t totalByteCount = magicByteCount + widthByteCount + heightByteCount + pixelByteCount;
+    unsigned char widthBytes[widthByteCount];
+    intToByteArray(width, widthBytes);
+    unsigned char heightBytes[heightByteCount];
+    intToByteArray(height, heightBytes);
+    unsigned char* rawBuf = new unsigned char[totalByteCount];
+    int offset = 0;
+    std::memcpy(rawBuf + offset, &depthMagicNumber, magicByteCount); 
+    offset += magicByteCount;
+    std::memcpy(rawBuf + offset, widthBytes, widthByteCount);
+    offset += widthByteCount;
+    std::memcpy(rawBuf + offset, heightBytes, heightByteCount);
+    offset += heightByteCount;
+    std::memcpy(rawBuf + offset, data, pixelByteCount);
+
+    if (DEBUG) {
+        auto stop = chrono::high_resolution_clock::now();
+        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
+        cout << "[GetImage]  RAW depth encode:      " << duration.count() << "ms\n";
+    }
+
+    return {rawBuf, totalByteCount, true};
+}
+
+grpc::Status encodeDepthRAWToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
+                                 const uint height) {
+    const auto& [encoded, encodedSize, ok] = encodeDepthRAW(data, width, height);
+    if (!ok) {
+        std::free(encoded);
+        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode depth RAW");
+    }
+    response->set_mime_type("image/vnd.viam.dep");
+    response->set_image(encoded, encodedSize);
+    std::free(encoded);
+    return grpc::Status::OK;
+}
+
+// COLOR responses
+tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width, const int height) {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    if (DEBUG) {
+        start = chrono::high_resolution_clock::now();
+    }
+
+    vector<uint8_t> encoded;
+    if (!fpng::fpng_encode_image_to_memory(data, width, height, 3, encoded)) {
+        cerr << "[GetImage]  failed to encode color PNG" << endl;
+        return {encoded, false};
+    }
+
+    if (DEBUG) {
+        auto stop = chrono::high_resolution_clock::now();
+        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
+        cout << "[GetImage]  PNG color encode:      " << duration.count() << "ms\n";
+    }
+
+    return {encoded, true};
+}
+
+grpc::Status encodeColorPNGToResponse(GetImageResponse* response, const uint8_t* data, const int width,
+                                 const int height) {
+    const auto& [encoded, ok] = encodeColorPNG(data, width, height);
+    if (!ok) {
+        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode color PNG");
+    }
+    response->set_mime_type("image/png");
+    response->set_image(encoded.data(), encoded.size());
+    return grpc::Status::OK;
+}
+
+tuple<unsigned char*, long unsigned int, bool> encodeJPEG(const unsigned char* data,
+                                                          const int width, const int height) {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    if (DEBUG) {
+        start = chrono::high_resolution_clock::now();
+    }
+
+    unsigned char* encoded = nullptr;
+    long unsigned int encodedSize = 0;
+    tjhandle handle = tjInitCompress();
+    if (handle == nullptr) {
+        cerr << "[GetImage]  failed to init JPEG compressor" << endl;
+        return {encoded, encodedSize, false};
+    }
+    tjCompress2(handle, data, width, 0, height, TJPF_RGB, &encoded, &encodedSize, TJSAMP_420, 75,
+                TJFLAG_FASTDCT);
+    tjDestroy(handle);
+
+    if (DEBUG) {
+        auto stop = chrono::high_resolution_clock::now();
+        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
+        cout << "[GetImage]  JPEG color encode:     " << duration.count() << "ms\n";
+    }
+
+    return {encoded, encodedSize, true};
+}
+
+grpc::Status encodeJPEGToResponse(GetImageResponse* response, const unsigned char* data,
+                                  const int width, const int height) {
+    const auto& [encoded, encodedSize, ok] = encodeJPEG(data, width, height);
+    if (!ok) {
+        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode color JPEG");
+    }
+    response->set_mime_type("image/jpeg");
+    response->set_image(encoded, encodedSize);
+    tjFree(encoded);
+    return grpc::Status::OK;
+}
+
 tuple<unsigned char*, size_t, bool> encodeColorRAW(const unsigned char* data, const uint32_t width, const uint32_t height) {
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (DEBUG) {
@@ -120,92 +277,6 @@ tuple<unsigned char*, size_t, bool> encodeColorRAW(const unsigned char* data, co
     return {rawBuf, totalByteCount, true};
 }
 
-
-tuple<unsigned char*, size_t, bool> encodeDepthRAW(const unsigned char* data, const uint64_t width, const uint64_t height) {
-    std::chrono::time_point<std::chrono::high_resolution_clock> start;
-    if (DEBUG) {
-        start = chrono::high_resolution_clock::now();
-    }
-
-    // Depth header contains 8 bytes worth of magic number, followed by 8 bytes for width and another 8 bytes for height 
-    // each pixel has 2 bytes.
-    size_t pixelByteCount = 2*width*height;
-    size_t magicByteCount = sizeof(depthMagicNumber);
-    size_t widthByteCount = sizeof(width);
-    size_t heightByteCount = sizeof(height);
-    size_t totalByteCount = magicByteCount + widthByteCount + heightByteCount + pixelByteCount;
-    unsigned char widthBytes[widthByteCount];
-    intToByteArray(width, widthBytes);
-    unsigned char heightBytes[heightByteCount];
-    intToByteArray(height, heightBytes);
-    unsigned char* rawBuf = new unsigned char[totalByteCount];
-    int offset = 0;
-    std::memcpy(rawBuf + offset, &depthMagicNumber, magicByteCount); 
-    offset += magicByteCount;
-    std::memcpy(rawBuf + offset, widthBytes, widthByteCount);
-    offset += widthByteCount;
-    std::memcpy(rawBuf + offset, heightBytes, heightByteCount);
-    offset += heightByteCount;
-    std::memcpy(rawBuf + offset, data, pixelByteCount);
-
-    if (DEBUG) {
-        auto stop = chrono::high_resolution_clock::now();
-        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
-        cout << "[GetImage]  RAW depth encode:      " << duration.count() << "ms\n";
-    }
-
-    return {rawBuf, totalByteCount, true};
-}
-
-
-tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, const uint width, const uint height) {
-    std::chrono::time_point<std::chrono::high_resolution_clock> start;
-    if (DEBUG) {
-        start = chrono::high_resolution_clock::now();
-    }
-
-    unsigned char* encoded = 0;
-    size_t encoded_size = 0;
-    unsigned result = lodepng_encode_memory(&encoded, &encoded_size, data, width, height, LCT_GREY, 16);
-    if (result != 0) {
-        cerr << "[GetImage]  failed to encode depth PNG" << endl;
-        return {encoded, encoded_size, false};
-    }
-
-    if (DEBUG) {
-        auto stop = chrono::high_resolution_clock::now();
-        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
-        cout << "[GetImage]  PNG depth encode:      " << duration.count() << "ms\n";
-    }
-
-    return {encoded, encoded_size, true};
-}
-
-grpc::Status encodeDepthPNGToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
-                                 const uint height) {
-    const auto& [encoded, encoded_size, ok] = encodeDepthPNG(data, width, height);
-    if (!ok) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode depth PNG");
-    }
-    response->set_mime_type("image/png");
-    response->set_image(encoded, encoded_size);
-    std::free(encoded);
-    return grpc::Status::OK;
-}
-
-grpc::Status encodeDepthRAWToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
-                                 const uint height) {
-    const auto& [encoded, encodedSize, ok] = encodeDepthRAW(data, width, height);
-    if (!ok) {
-        std::free(encoded);
-        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode depth RAW");
-    }
-    response->set_mime_type("image/vnd.viam.dep");
-    response->set_image(encoded, encodedSize);
-    std::free(encoded);
-    return grpc::Status::OK;
-}
-
 grpc::Status encodeColorRAWToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
                                  const uint height) {
     const auto& [encoded, encodedSize, ok] = encodeColorRAW(data, width, height);
@@ -219,78 +290,7 @@ grpc::Status encodeColorRAWToResponse(GetImageResponse* response, const unsigned
     return grpc::Status::OK;
 }
 
-tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width, const int height) {
-    std::chrono::time_point<std::chrono::high_resolution_clock> start;
-    if (DEBUG) {
-        start = chrono::high_resolution_clock::now();
-    }
-
-    vector<uint8_t> encoded;
-    if (!fpng::fpng_encode_image_to_memory(data, width, height, 3, encoded)) {
-        cerr << "[GetImage]  failed to encode color PNG" << endl;
-        return {encoded, false};
-    }
-
-    if (DEBUG) {
-        auto stop = chrono::high_resolution_clock::now();
-        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
-        cout << "[GetImage]  PNG color encode:      " << duration.count() << "ms\n";
-    }
-
-    return {encoded, true};
-}
-
-grpc::Status encodeColorPNGToResponse(GetImageResponse* response, const uint8_t* data, const int width,
-                                 const int height) {
-    const auto& [encoded, ok] = encodeColorPNG(data, width, height);
-    if (!ok) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode color PNG");
-    }
-    response->set_mime_type("image/png");
-    response->set_image(encoded.data(), encoded.size());
-    return grpc::Status::OK;
-}
-
-
-tuple<unsigned char*, long unsigned int, bool> encodeJPEG(const unsigned char* data,
-                                                          const int width, const int height) {
-    std::chrono::time_point<std::chrono::high_resolution_clock> start;
-    if (DEBUG) {
-        start = chrono::high_resolution_clock::now();
-    }
-
-    unsigned char* encoded = nullptr;
-    long unsigned int encodedSize = 0;
-    tjhandle handle = tjInitCompress();
-    if (handle == nullptr) {
-        cerr << "[GetImage]  failed to init JPEG compressor" << endl;
-        return {encoded, encodedSize, false};
-    }
-    tjCompress2(handle, data, width, 0, height, TJPF_RGB, &encoded, &encodedSize, TJSAMP_420, 75,
-                TJFLAG_FASTDCT);
-    tjDestroy(handle);
-
-    if (DEBUG) {
-        auto stop = chrono::high_resolution_clock::now();
-        auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
-        cout << "[GetImage]  JPEG color encode:     " << duration.count() << "ms\n";
-    }
-
-    return {encoded, encodedSize, true};
-}
-
-grpc::Status encodeJPEGToResponse(GetImageResponse* response, const unsigned char* data,
-                                  const int width, const int height) {
-    const auto& [encoded, encodedSize, ok] = encodeJPEG(data, width, height);
-    if (!ok) {
-        return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode color JPEG");
-    }
-    response->set_mime_type("image/jpeg");
-    response->set_image(encoded, encodedSize);
-    tjFree(encoded);
-    return grpc::Status::OK;
-}
-
+// CAMERA service
 class CameraServiceImpl final : public CameraService::Service {
    private:
     RealSenseProperties props;

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -72,15 +72,15 @@ struct AtomicFrameSet {
 bool DEBUG = false;
 const uint32_t rgbaMagicNumber =
     htonl(1380401729);                 // the utf-8 binary encoding for "RGBA", big-endian
-const size_t rgbaMagicByteCount = 4;   // number of bytes used to represent the rgba magic number
-const size_t rgbaWidthByteCount = 4;   // number of bytes used to represent rgba image width
-const size_t rgbaHeightByteCount = 4;  // number of bytes used to represent rgba image height
+const size_t rgbaMagicByteCount = sizeof(uint32_t);   // number of bytes used to represent the rgba magic number
+const size_t rgbaWidthByteCount = sizeof(uint32_t);   // number of bytes used to represent rgba image width
+const size_t rgbaHeightByteCount = sizeof(uint32_t);  // number of bytes used to represent rgba image height
 
 const uint64_t depthMagicNumber =
     htonll(4919426490892632400);        // the utf-8 binary encoding for "DEPTHMAP", big-endian
-const size_t depthMagicByteCount = 8;   // number of bytes used to represent the depth magic number
-const size_t depthWidthByteCount = 8;   // number of bytes used to represent depth image width
-const size_t depthHeightByteCount = 8;  // number of bytes used to represent depth image height
+const size_t depthMagicByteCount = sizeof(uint64_t);   // number of bytes used to represent the depth magic number
+const size_t depthWidthByteCount = sizeof(uint64_t);   // number of bytes used to represent depth image width
+const size_t depthHeightByteCount = sizeof(uint64_t);  // number of bytes used to represent depth image height
 
 // COLOR responses
 tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width,

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -280,6 +280,10 @@ class RobotServiceImpl final : public RobotService::Service {
         depthName->set_name("depth");
         return grpc::Status::OK;
     }
+    grpc::Status StreamStatus(ServerContext* context, const StreamStatusRequest* request,
+                               StreamStatusResponse* response) override {
+        return grpc::Status::OK;
+    }
 };
 
 // align to the color camera's origin when color and depth enabled

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -280,10 +280,6 @@ class RobotServiceImpl final : public RobotService::Service {
         depthName->set_name("depth");
         return grpc::Status::OK;
     }
-    grpc::Status StreamStatus(ServerContext* context, const StreamStatusRequest* request,
-                               StreamStatusResponse* response) override {
-        return grpc::Status::OK;
-    }
 };
 
 // align to the color camera's origin when color and depth enabled

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <grpc/grpc.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
@@ -18,8 +19,8 @@
 #include "component/camera/v1/camera.pb.h"
 #include "robot/v1/robot.grpc.pb.h"
 #include "robot/v1/robot.pb.h"
-#include "third_party/lodepng.h"
 #include "third_party/fpng.h"
+#include "third_party/lodepng.h"
 
 using namespace std;
 using grpc::Server;
@@ -36,6 +37,9 @@ using viam::component::camera::v1::IntrinsicParameters;
 using viam::robot::v1::ResourceNamesRequest;
 using viam::robot::v1::ResourceNamesResponse;
 using viam::robot::v1::RobotService;
+
+#define htonll(x) \
+    ((1 == htonl(1)) ? (x) : ((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32))
 
 struct CameraProperties {
     int width;
@@ -66,20 +70,73 @@ struct AtomicFrameSet {
 };
 
 bool DEBUG = false;
-const uint32_t rgbaMagicNumber = 1094862674; // the utf-8 binary encoding for "RGBA", big-endian
-const uint64_t depthMagicNumber = 5782988369567958340; // the utf-8 binary encoding for "DEPTHMAP", big-endian
+const uint32_t rgbaMagicNumber = 1094862674;  // the utf-8 binary encoding for "RGBA"
+const size_t rgbaMagicByteCount = 4;   // number of bytes used to represent the rgba magic number
+const size_t rgbaWidthByteCount = 4;   // number of bytes used to represent rgba image width
+const size_t rgbaHeightByteCount = 4;  // number of bytes used to represent rgba image height
 
-void intToByteArray(const uint num, unsigned char* intBytes) {
-    size_t nBytes = sizeof(intBytes);
-    int shift = nBytes*8;
-    for (int i = 0; i < nBytes; i++) {
-        shift = shift - 8;
-        intBytes[i] = (num >> shift) & 0xFF;
+const uint64_t depthMagicNumber = 5782988369567958340;  // the utf-8 binary encoding for "DEPTHMAP"
+const size_t depthMagicByteCount = 8;   // number of bytes used to represent the depth magic number
+const size_t depthWidthByteCount = 8;   // number of bytes used to represent depth image width
+const size_t depthHeightByteCount = 8;  // number of bytes used to represent depth image height
+
+tuple<unsigned char*, size_t> encodeRAW(uint64_t magicNumber, uint64_t width, uint64_t height,
+                                        const unsigned char* data) {
+    // set size of raw file
+    size_t magicByteCount = 0;
+    size_t widthByteCount = 0;
+    size_t heightByteCount = 0;
+    size_t pixelByteCount = 0;
+    uint64_t widthToEncode = width;
+    uint64_t heightToEncode = height;
+    if (magicNumber == rgbaMagicNumber) {
+        // copy the 4 bytes of height and width in the higher register of uint64_t
+        // in order to make sure that conversion to big-endian does not mess up the uint32_t
+        // dimensions for rgba.
+        widthToEncode = width << 32 | width;
+        heightToEncode = height << 32 | height;
+        magicByteCount = rgbaMagicByteCount;
+        widthByteCount = rgbaWidthByteCount;
+        heightByteCount = rgbaHeightByteCount;
+        pixelByteCount = 4 * width * height;  // 4 bytes for RGBA
+    } else if (magicNumber == depthMagicNumber) {
+        magicByteCount = depthMagicByteCount;
+        widthByteCount = depthWidthByteCount;
+        heightByteCount = depthHeightByteCount;
+        pixelByteCount = 2 * width * height;  // 2 bytes for Z16
+    } else {
+        throw std::runtime_error("encodeRAW: data is not depth nor color data");
     }
+    widthToEncode = htonll(widthToEncode);    // make sure everything is big-endian
+    heightToEncode = htonll(heightToEncode);  // make sure everything is big-endian
+    size_t totalByteCount = magicByteCount + widthByteCount + heightByteCount + pixelByteCount;
+    // memcpy data into buffer
+    unsigned char* rawBuf = new unsigned char[totalByteCount];
+    int offset = 0;
+    std::memcpy(rawBuf + offset, &magicNumber, magicByteCount);
+    offset += magicByteCount;
+    std::memcpy(rawBuf + offset, &widthToEncode, widthByteCount);
+    offset += widthByteCount;
+    std::memcpy(rawBuf + offset, &heightToEncode, heightByteCount);
+    offset += heightByteCount;
+    if (magicNumber == rgbaMagicNumber) {
+        int pixelOffset = 0;
+        uint8_t alphaValue = 255;  // alpha  channel is always 255 for color images
+        for (int i = 0; i < width * height; i++) {
+            std::memcpy(rawBuf + offset, data + pixelOffset, 3);  // 3 bytes for RGB
+            std::memcpy(rawBuf + offset + 3, &alphaValue, 1);     // 1 byte for A
+            pixelOffset += 3;
+            offset += 4;
+        }
+    } else {
+        std::memcpy(rawBuf + offset, data, pixelByteCount);
+    }
+    return {rawBuf, totalByteCount};
 }
 
 // COLOR responses
-tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width, const int height) {
+tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width,
+                                            const int height) {
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (DEBUG) {
         start = chrono::high_resolution_clock::now();
@@ -100,8 +157,8 @@ tuple<vector<uint8_t>, bool> encodeColorPNG(const uint8_t* data, const int width
     return {encoded, true};
 }
 
-grpc::Status encodeColorPNGToResponse(GetImageResponse* response, const uint8_t* data, const int width,
-                                 const int height) {
+grpc::Status encodeColorPNGToResponse(GetImageResponse* response, const uint8_t* data,
+                                      const int width, const int height) {
     const auto& [encoded, ok] = encodeColorPNG(data, width, height);
     if (!ok) {
         return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode color PNG");
@@ -150,50 +207,25 @@ grpc::Status encodeJPEGToResponse(GetImageResponse* response, const unsigned cha
     return grpc::Status::OK;
 }
 
-tuple<unsigned char*, size_t, bool> encodeColorRAW(const unsigned char* data, const uint32_t width, const uint32_t height) {
+tuple<unsigned char*, size_t, bool> encodeColorRAW(const unsigned char* data, const uint32_t width,
+                                                   const uint32_t height) {
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (DEBUG) {
         start = chrono::high_resolution_clock::now();
     }
+    const auto& [encoded, encodedSize] = encodeRAW(rgbaMagicNumber, width, height, data);
 
-    // Color header contains 4 bytes worth of magic number, followed by 4 bytes for width and another 4 bytes for height 
-    // each pixel has 4 bytes, one for each channel (RGBA).
-    size_t pixelByteCount = 4*width*height;
-    size_t magicByteCount = sizeof(rgbaMagicNumber);
-    size_t widthByteCount = sizeof(width);
-    size_t heightByteCount = sizeof(height);
-    size_t totalByteCount = magicByteCount + widthByteCount + heightByteCount + pixelByteCount;
-    unsigned char widthBytes[widthByteCount];
-    intToByteArray(width, widthBytes);
-    unsigned char heightBytes[heightByteCount];
-    intToByteArray(height, heightBytes);
-    unsigned char* rawBuf = new unsigned char[totalByteCount];
-    int offset = 0;
-    std::memcpy(rawBuf + offset, &rgbaMagicNumber, magicByteCount); 
-    offset += magicByteCount;
-    std::memcpy(rawBuf + offset, widthBytes, widthByteCount);
-    offset += widthByteCount;
-    std::memcpy(rawBuf + offset, heightBytes, heightByteCount);
-    offset += heightByteCount;
-    int pixelOffset = 0;
-    uint8_t alphaValue = 255; // alpha  channel is always 255 for color images
-    for (int i = 0; i < width*height; i++) {
-        std::memcpy(rawBuf + offset, data + pixelOffset, 3); // 3 bytes for RGB
-        std::memcpy(rawBuf + offset+3, &alphaValue, 1); // 1 byte for A
-        pixelOffset += 3;
-        offset += 4;
-    }
     if (DEBUG) {
         auto stop = chrono::high_resolution_clock::now();
         auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
         cout << "[GetImage]  RAW color encode:      " << duration.count() << "ms\n";
     }
 
-    return {rawBuf, totalByteCount, true};
+    return {encoded, encodedSize, true};
 }
 
-grpc::Status encodeColorRAWToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
-                                 const uint height) {
+grpc::Status encodeColorRAWToResponse(GetImageResponse* response, const unsigned char* data,
+                                      const uint width, const uint height) {
     const auto& [encoded, encodedSize, ok] = encodeColorRAW(data, width, height);
     if (!ok) {
         std::free(encoded);
@@ -206,7 +238,8 @@ grpc::Status encodeColorRAWToResponse(GetImageResponse* response, const unsigned
 }
 
 // DEPTH responses
-tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, const uint width, const uint height) {
+tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, const uint width,
+                                                   const uint height) {
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (DEBUG) {
         start = chrono::high_resolution_clock::now();
@@ -214,7 +247,8 @@ tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, co
 
     unsigned char* encoded = 0;
     size_t encoded_size = 0;
-    unsigned result = lodepng_encode_memory(&encoded, &encoded_size, data, width, height, LCT_GREY, 16);
+    unsigned result =
+        lodepng_encode_memory(&encoded, &encoded_size, data, width, height, LCT_GREY, 16);
     if (result != 0) {
         cerr << "[GetImage]  failed to encode depth PNG" << endl;
         return {encoded, encoded_size, false};
@@ -229,8 +263,8 @@ tuple<unsigned char*, size_t, bool> encodeDepthPNG(const unsigned char* data, co
     return {encoded, encoded_size, true};
 }
 
-grpc::Status encodeDepthPNGToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
-                                 const uint height) {
+grpc::Status encodeDepthPNGToResponse(GetImageResponse* response, const unsigned char* data,
+                                      const uint width, const uint height) {
     const auto& [encoded, encoded_size, ok] = encodeDepthPNG(data, width, height);
     if (!ok) {
         return grpc::Status(grpc::StatusCode::INTERNAL, "failed to encode depth PNG");
@@ -241,32 +275,15 @@ grpc::Status encodeDepthPNGToResponse(GetImageResponse* response, const unsigned
     return grpc::Status::OK;
 }
 
-tuple<unsigned char*, size_t, bool> encodeDepthRAW(const unsigned char* data, const uint64_t width, const uint64_t height) {
+tuple<unsigned char*, size_t, bool> encodeDepthRAW(const unsigned char* data, const uint64_t width,
+                                                   const uint64_t height) {
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
     if (DEBUG) {
         start = chrono::high_resolution_clock::now();
     }
-
-    // Depth header contains 8 bytes worth of magic number, followed by 8 bytes for width and another 8 bytes for height 
-    // each pixel has 2 bytes.
-    size_t pixelByteCount = 2*width*height;
-    size_t magicByteCount = sizeof(depthMagicNumber);
-    size_t widthByteCount = sizeof(width);
-    size_t heightByteCount = sizeof(height);
-    size_t totalByteCount = magicByteCount + widthByteCount + heightByteCount + pixelByteCount;
-    unsigned char widthBytes[widthByteCount];
-    intToByteArray(width, widthBytes);
-    unsigned char heightBytes[heightByteCount];
-    intToByteArray(height, heightBytes);
-    unsigned char* rawBuf = new unsigned char[totalByteCount];
-    int offset = 0;
-    std::memcpy(rawBuf + offset, &depthMagicNumber, magicByteCount); 
-    offset += magicByteCount;
-    std::memcpy(rawBuf + offset, widthBytes, widthByteCount);
-    offset += widthByteCount;
-    std::memcpy(rawBuf + offset, heightBytes, heightByteCount);
-    offset += heightByteCount;
-    std::memcpy(rawBuf + offset, data, pixelByteCount);
+    // Depth header contains 8 bytes worth of magic number, followed by 8 bytes for width and
+    // another 8 bytes for height each pixel has 2 bytes.
+    const auto& [encoded, encodedSize] = encodeRAW(depthMagicNumber, width, height, data);
 
     if (DEBUG) {
         auto stop = chrono::high_resolution_clock::now();
@@ -274,11 +291,11 @@ tuple<unsigned char*, size_t, bool> encodeDepthRAW(const unsigned char* data, co
         cout << "[GetImage]  RAW depth encode:      " << duration.count() << "ms\n";
     }
 
-    return {rawBuf, totalByteCount, true};
+    return {encoded, encodedSize, true};
 }
 
-grpc::Status encodeDepthRAWToResponse(GetImageResponse* response, const unsigned char* data, const uint width,
-                                 const uint height) {
+grpc::Status encodeDepthRAWToResponse(GetImageResponse* response, const unsigned char* data,
+                                      const uint width, const uint height) {
     const auto& [encoded, encodedSize, ok] = encodeDepthRAW(data, width, height);
     if (!ok) {
         std::free(encoded);
@@ -289,7 +306,6 @@ grpc::Status encodeDepthRAWToResponse(GetImageResponse* response, const unsigned
     std::free(encoded);
     return grpc::Status::OK;
 }
-
 
 // CAMERA service
 class CameraServiceImpl final : public CameraService::Service {
@@ -325,12 +341,14 @@ class CameraServiceImpl final : public CameraService::Service {
             if (this->disableColor) {
                 return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "color disabled");
             }
-            if (reqMimeType.compare("image/png") == 0 || reqMimeType.compare("image/png+lazy") == 0) {
+            if (reqMimeType.compare("image/png") == 0 ||
+                reqMimeType.compare("image/png+lazy") == 0) {
                 encodeColorPNGToResponse(response, (const uint8_t*)latestColorFrame.get_data(),
-                                    this->props.color.width, this->props.color.height);
+                                         this->props.color.width, this->props.color.height);
             } else if (reqMimeType.compare("image/vnd.viam.rgba") == 0) {
-                encodeColorRAWToResponse(response, (const unsigned char*)latestColorFrame.get_data(),
-                                    this->props.color.width, this->props.color.height);
+                encodeColorRAWToResponse(response,
+                                         (const unsigned char*)latestColorFrame.get_data(),
+                                         this->props.color.width, this->props.color.height);
             } else {
                 encodeJPEGToResponse(response, (const unsigned char*)latestColorFrame.get_data(),
                                      this->props.color.width, this->props.color.height);
@@ -341,10 +359,10 @@ class CameraServiceImpl final : public CameraService::Service {
             }
             if (reqMimeType.compare("image/vnd.viam.dep") == 0) {
                 encodeDepthRAWToResponse(response, (const unsigned char*)latestDepthFrame->data(),
-                                    this->props.color.width, this->props.color.height);
-	        } else {
-                encodeDepthPNGToResponse(response, (const unsigned char*)latestDepthFrame->data(), this->props.depth.width,
-	    		    this->props.depth.height);
+                                         this->props.color.width, this->props.color.height);
+            } else {
+                encodeDepthPNGToResponse(response, (const unsigned char*)latestDepthFrame->data(),
+                                         this->props.depth.width, this->props.depth.height);
             }
         }
 
@@ -455,30 +473,29 @@ void frameLoop(rs2::pipeline pipeline, AtomicFrameSet& frameSet, promise<void>& 
                 auto duration = chrono::duration_cast<chrono::milliseconds>(stop - start);
                 cout << "[frameLoop] frame alignment: " << duration.count() << "ms\n";
             }
-	}
-	// scale every pixel value to be depth in units of mm
-	unique_ptr<vector<uint16_t>> depthFrameScaled;
+        }
+        // scale every pixel value to be depth in units of mm
+        unique_ptr<vector<uint16_t>> depthFrameScaled;
         if (!disableDepth) {
-		auto depthFrame = frames.get_depth_frame();
-		auto depthWidth = depthFrame.get_width();
-		auto depthHeight = depthFrame.get_height();
-		const uint16_t* depthFrameData = (const uint16_t*)depthFrame.get_data();
-        // NOTE(erd): this is fast enough in -O3 (1920x1080 -> ~15ms) but could probably be
-        // better
-		depthFrameScaled = make_unique<vector<uint16_t>>(depthWidth * depthHeight);
-	        for (int y = 0; y < depthHeight; y++) {
-	            for (int x = 0; x < depthWidth; x++) {
-		        auto px = (y * depthWidth) + x;
-			uint16_t depthScaled = depthScaleMm * depthFrameData[px];
-			(*depthFrameScaled)[px] = depthScaled;
-	           }
-		}
-	}
+            auto depthFrame = frames.get_depth_frame();
+            auto depthWidth = depthFrame.get_width();
+            auto depthHeight = depthFrame.get_height();
+            const uint16_t* depthFrameData = (const uint16_t*)depthFrame.get_data();
+            // NOTE(erd): this is fast enough in -O3 (1920x1080 -> ~15ms) but could probably be
+            // better
+            depthFrameScaled = make_unique<vector<uint16_t>>(depthWidth * depthHeight);
+            for (int y = 0; y < depthHeight; y++) {
+                for (int x = 0; x < depthWidth; x++) {
+                    auto px = (y * depthWidth) + x;
+                    uint16_t depthScaled = depthScaleMm * depthFrameData[px];
+                    (*depthFrameScaled)[px] = depthScaled;
+                }
+            }
+        }
         frameSet.mutex.lock();
         frameSet.colorFrame = frames.get_color_frame();
         frameSet.depthFrame = move(depthFrameScaled);
         frameSet.mutex.unlock();
-
 
         if (DEBUG) {
             auto stop = chrono::high_resolution_clock::now();
@@ -494,15 +511,12 @@ void frameLoop(rs2::pipeline pipeline, AtomicFrameSet& frameSet, promise<void>& 
 };
 
 // gives the pixel to mm conversion for the depth sensor
-float getDepthScale(rs2::device dev)
-{
+float getDepthScale(rs2::device dev) {
     // Go over the device's sensors
-    for (rs2::sensor& sensor : dev.query_sensors())
-    {
+    for (rs2::sensor& sensor : dev.query_sensors()) {
         // Check if the sensor if a depth sensor
-        if (rs2::depth_sensor dpt = sensor.as<rs2::depth_sensor>())
-        {
-            return dpt.get_depth_scale() * 1000.0; // rs2 gives pix2meters
+        if (rs2::depth_sensor dpt = sensor.as<rs2::depth_sensor>()) {
+            return dpt.get_depth_scale() * 1000.0;  // rs2 gives pix2meters
         }
     }
     throw std::runtime_error("Device does not have a depth sensor");
@@ -528,7 +542,7 @@ const PipelineWithProperties startPipeline(const int colorWidth, const int color
 
     float depthScaleMm = 0.0;
     if (!disableDepth) {
-	    depthScaleMm = getDepthScale(selected_device);
+        depthScaleMm = getDepthScale(selected_device);
     }
 
     rs2::config cfg;

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -334,7 +334,7 @@ void frameLoop(rs2::pipeline pipeline, AtomicFrameSet& frameSet, promise<void>& 
 	// scale every pixel value to be depth in units of mm
 	unique_ptr<vector<uint16_t>> depthFrameScaled;
         if (!disableDepth) {
-		auto depthFrame = frames.get_depth_frame();
+		auto depthFrame = frames.getDepthFrame();
 		auto depthWidth = depthFrame.get_width();
 		auto depthHeight = depthFrame.get_height();
 		const uint16_t* depthFrameData = (const uint16_t*)depthFrame.get_data();
@@ -377,7 +377,7 @@ float getDepthScale(rs2::device dev)
         // Check if the sensor if a depth sensor
         if (rs2::depth_sensor dpt = sensor.as<rs2::depth_sensor>())
         {
-            return dpt.get_depth_scale() * 1000.0; // rs2 gives pix2meters
+            return dpt.getDepthScale() * 1000.0; // rs2 gives pix2meters
         }
     }
     throw std::runtime_error("Device does not have a depth sensor");


### PR DESCRIPTION
Tested raw requests from the GRPC server using the python SDK, and got an **avg FPS of  44.65** for the 640x480 Depth images.  It might be able to be faster - I feel like I probably didn't use memcpy in the most efficient way.

Right now, we don't have a way to convert Raw Depth images in python to PIL images, this will be taken care of with https://viam.atlassian.net/browse/RSDK-1623

The Raw Color image is actually pretty slow, at 19 FPS, I suspect because I have to insert the Alpha channel into the stream (the intel realsense only has the RGB channels). But it does copy the bytes correctly:
![tmpfh0ft0jg](https://user-images.githubusercontent.com/8298653/220476279-49998bff-261f-44ae-a860-94ec9459f0ef.jpg)

