### PR TITLE
RSDK-2727 - have intel realsense automatically reconnect when device is found again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ ifeq ($(UNAME), Darwin)
 	# There's a strange bug in the realsense pc file that adds this when it's not necessary at all
 	# when brew is in use. This may break something in the future.
    LIB_FLAGS := $(LIB_FLAGS:-L/usr/local/lib/x86_64-linux-gnu=)
-   include *.make
 endif
 
 GRPC_DIR = ./

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ifeq ($(UNAME), Darwin)
 	# There's a strange bug in the realsense pc file that adds this when it's not necessary at all
 	# when brew is in use. This may break something in the future.
    LIB_FLAGS := $(LIB_FLAGS:-L/usr/local/lib/x86_64-linux-gnu=)
+   include *.make
 endif
 
 GRPC_DIR = ./

--- a/intel_realsense_grpc.cpp
+++ b/intel_realsense_grpc.cpp
@@ -6,7 +6,6 @@
 #include <grpcpp/server_context.h>
 #include <turbojpeg.h>
 
-#include <condition_variable>
 #include <future>
 #include <iostream>
 #include <librealsense2/rs.hpp>


### PR DESCRIPTION
Previously, unplugging the intel realsense from the raspberry pi would cause the stream to indefinitely freeze on the last seen frame, even if the realsense was plugged back in.

This PR uses the rs2::set_devices_changed_callback function to notice when a Realsense is reconnected to the the raspberry pi, exiting out of the old camera thread, and starting a new camera thread. 

I tested this out on a D435 intel realsense, and the viam-server resumes streaming the cameras after the camera is unplugged and plugged back in. 